### PR TITLE
Fix remote control on android 17+ by adding permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,11 +19,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
     <application
         android:name=".HowlApp"
         android:allowBackup="false"
+        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,6 @@
     <application
         android:name=".HowlApp"
         android:allowBackup="false"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/example/howl/HowlActivity.kt
+++ b/app/src/main/java/com/example/howl/HowlActivity.kt
@@ -81,6 +81,30 @@ fun HowlAppScreen(
         }
     }
 
+    val LOCAL_NETWORK_PERMISSION = android.Manifest.permission.ACCESS_LOCAL_NETWORK
+    val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            HLog.d("Howl", "Local network permission granted.")
+            settingsViewModel.setRemoteAccess(true)
+        } else {
+            HLog.d("Howl", "Local network permission denied.")
+        }
+    }
+
+    fun onAllowRemoteAccess(enabled: Boolean) {
+        if (!enabled) {
+            settingsViewModel.setRemoteAccess(false)
+            return
+        }
+        if (ContextCompat.checkSelfPermission(context, LOCAL_NETWORK_PERMISSION) == PackageManager.PERMISSION_GRANTED) {
+            settingsViewModel.setRemoteAccess(true)
+        } else {
+            localNetworkPermissionLauncher.launch(LOCAL_NETWORK_PERMISSION)
+        }
+    }
+
     // Keep the screen on whenever the player is playing
     val view = LocalView.current
     LaunchedEffect(playerState.isPlaying) {
@@ -111,6 +135,7 @@ fun HowlAppScreen(
                 settingsViewModel = settingsViewModel,
                 generatorViewModel = generatorViewModel,
                 activityHostViewModel = activityHostViewModel,
+                onAllowRemoteAccess = { onAllowRemoteAccess(it) },
             )
         }
     }

--- a/app/src/main/java/com/example/howl/Settings.kt
+++ b/app/src/main/java/com/example/howl/Settings.kt
@@ -406,6 +406,7 @@ fun PowerSettingsPanel(
 @Composable
 fun SettingsPanel(
     viewModel: SettingsViewModel,
+    onAllowRemoteAccess: ((Boolean) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val miscShowPowerMeter by Prefs.miscShowPowerMeter.collectAsStateWithLifecycle()
@@ -432,7 +433,7 @@ fun SettingsPanel(
             label = "Allow remote access",
             checked = remoteAccess,
             onCheckedChange = {
-                viewModel.setRemoteAccess(it)
+                onAllowRemoteAccess?.invoke(it) ?: viewModel.setRemoteAccess(it)
             }
         )
         val bearerRegex = Regex("[^A-Za-z0-9._~+/=-]")

--- a/app/src/main/java/com/example/howl/TabLayout.kt
+++ b/app/src/main/java/com/example/howl/TabLayout.kt
@@ -58,6 +58,7 @@ fun TabLayout(
     settingsViewModel: SettingsViewModel,
     generatorViewModel: GeneratorViewModel,
     activityHostViewModel: ActivityHostViewModel,
+    onAllowRemoteAccess: ((Boolean) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val tabIndex by tabLayoutViewModel.tabIndex.collectAsState()
@@ -108,7 +109,7 @@ fun TabLayout(
                 "Player" -> CombinedPanel(viewModel = playerViewModel)
                 "Generator" -> GeneratorPanel(viewModel = generatorViewModel)
                 "Activity" -> ActivityHostPanel(viewModel = activityHostViewModel)
-                "Settings" -> SettingsPanel(viewModel = settingsViewModel)
+                "Settings" -> SettingsPanel(viewModel = settingsViewModel, onAllowRemoteAccess = onAllowRemoteAccess)
                 "Debug" -> LogViewer()
             }
         }


### PR DESCRIPTION
Remote Control does not work on newer builds of Android 17 as apps require the `ACCESS_LOCAL_NETWORK` if they want to open a port reachable via WiFi.

Permission is automatically granted during install, no user prompts.