### PR TITLE
Add retry logic for Bluetooth connection

### DIFF
--- a/app/src/main/java/com/example/howl/BluetoothHandler.kt
+++ b/app/src/main/java/com/example/howl/BluetoothHandler.kt
@@ -8,11 +8,7 @@ import android.util.Log
 import java.lang.ref.WeakReference
 import java.util.UUID
 import android.Manifest
-import android.content.pm.PackageManager
-import androidx.core.content.ContextCompat
-import androidx.core.app.ActivityCompat
 import android.bluetooth.le.ScanCallback
-import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanSettings
 import android.annotation.SuppressLint
 import android.os.Handler
@@ -65,6 +61,11 @@ object BluetoothHandler {
     private val clientConfigDescriptor = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     const val PERMISSION_BLUETOOTH_SCAN = "android.permission.BLUETOOTH_SCAN"
     const val PERMISSION_BLUETOOTH_CONNECT = "android.permission.BLUETOOTH_CONNECT"
+    private const val MAX_CONNECTION_RETRIES = 3
+    private const val CONNECTION_RETRY_DELAY_MS = 500L
+    private const val CONNECTION_SETTLE_DELAY_MS = 500L
+    private var connectionRetryCount = 0
+    private var connectionRetryHandler: Handler? = null
 
     val ALL_BLE_PERMISSIONS = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         arrayOf(Manifest.permission.BLUETOOTH_CONNECT, Manifest.permission.BLUETOOTH_SCAN)
@@ -105,12 +106,9 @@ object BluetoothHandler {
         }
 
         val scanner = adapter.bluetoothLeScanner
-        val scanFilters = supportedDevices.map {
-            ScanFilter.Builder().setDeviceName(it.deviceName).build()
-        }
+        // Use a permissive scan without name filters so we can log all found devices
         val scanSettings = ScanSettings.Builder()
             .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-            .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
             .build()
 
         val timeoutHandler = Handler(Looper.getMainLooper())
@@ -118,13 +116,18 @@ object BluetoothHandler {
         val scanCallback = object : ScanCallback() {
             override fun onScanResult(type: Int, result: ScanResult?) {
                 result?.let {
-                    bluetoothDevice = it.device
-                    val foundDevice = supportedDevices.find { sd -> sd.deviceName == bluetoothDevice?.name }
+                    val deviceName = it.device?.name ?: "unnamed"
+                    // Check against our known device names (software matching instead of hardware filter)
+                    val foundDevice = supportedDevices.find { sd -> sd.deviceName == deviceName }
                     if (foundDevice != null) {
+                        bluetoothDevice = it.device
                         HLog.d(TAG, "Found ${foundDevice.deviceName}, connecting...")
                         timeoutHandler.removeCallbacksAndMessages(null)
                         scanner?.stopScan(this)
-                        connectToDevice(foundDevice)
+                        // Small delay to let the BLE stack settle before connecting
+                        Handler(Looper.getMainLooper()).postDelayed({
+                            connectToDevice(foundDevice)
+                        }, CONNECTION_SETTLE_DELAY_MS)
                     }
                 }
             }
@@ -135,7 +138,7 @@ object BluetoothHandler {
         }
 
         HLog.d(TAG, "Starting BLE scan...")
-        scanner?.startScan(scanFilters, scanSettings, scanCallback)
+        scanner?.startScan(emptyList(), scanSettings, scanCallback)
 
         timeoutHandler.postDelayed({
             HLog.d(TAG, "Scan timeout, disconnecting.")
@@ -148,15 +151,56 @@ object BluetoothHandler {
     private fun connectToDevice(deviceInfo: SupportedDevice) {
         onConnectionStatusUpdate?.invoke(ConnectionStatus.Connecting)
         Player.switchOutput(deviceInfo.outputType)
-        gatt = bluetoothDevice?.connectGatt(contextRef?.get(), false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+        // Cancel any pending retry
+        connectionRetryHandler?.removeCallbacksAndMessages(null)
+        connectionRetryHandler = null
+        // Close any existing GATT connection before creating a new one
+        // but save the device reference since we need it below
+        val device = bluetoothDevice
+        closeGatt()
+        bluetoothDevice = device
+        connectionRetryCount = 0
+        gatt = device?.connectGatt(contextRef?.get(), false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+        if (gatt == null) {
+            HLog.d(TAG, "connectGatt returned null, scheduling retry...")
+            scheduleRetry(deviceInfo)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun closeGatt() {
+        try {
+            gatt?.disconnect()
+            gatt?.close()
+        } catch (e: Exception) {
+            HLog.d(TAG, "Error closing GATT: ${e.message}")
+        }
+        gatt = null
+        bluetoothDevice = null
+    }
+
+    private fun scheduleRetry(deviceInfo: SupportedDevice) {
+        if (connectionRetryCount >= MAX_CONNECTION_RETRIES) {
+            HLog.d(TAG, "Max connection retries reached")
+            onConnectionStatusUpdate?.invoke(ConnectionStatus.Disconnected)
+            Player.output.handleBluetoothEvent(BluetoothEvent(type = BluetoothEventType.Disconnected))
+            return
+        }
+        connectionRetryCount++
+        HLog.d(TAG, "Retrying connection (attempt ${connectionRetryCount}/$MAX_CONNECTION_RETRIES)...")
+        onConnectionStatusUpdate?.invoke(ConnectionStatus.Connecting)
+        connectionRetryHandler = Handler(Looper.getMainLooper())
+        connectionRetryHandler?.postDelayed({
+            // Re-scan for the device since the BluetoothDevice reference may be stale
+            scanForDevices()
+        }, CONNECTION_RETRY_DELAY_MS)
     }
 
     @SuppressLint("MissingPermission")
     fun disconnect() {
-        gatt?.disconnect()
-        gatt?.close()
-        gatt = null
-        bluetoothDevice = null
+        connectionRetryHandler?.removeCallbacksAndMessages(null)
+        connectionRetryHandler = null
+        closeGatt()
         Player.output.handleBluetoothEvent(BluetoothEvent(type = BluetoothEventType.Disconnected))
         onConnectionStatusUpdate?.invoke(ConnectionStatus.Disconnected)
     }
@@ -166,11 +210,23 @@ object BluetoothHandler {
         @RequiresPermission(PERMISSION_BLUETOOTH_CONNECT)
         override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
+                HLog.d(TAG, "Connection state change error: status=$status newState=$newState")
+                // Retry on transient connection errors rather than giving up immediately
+                // Common retryable status codes: 62 (establishment failure), 133 (GATT_ERROR), 257 (timeout)
+                if (connectionRetryCount < MAX_CONNECTION_RETRIES) {
+                    val deviceName = bluetoothDevice?.name ?: "unknown"
+                    val deviceInfo = supportedDevices.find { it.deviceName == deviceName }
+                    if (deviceInfo != null) {
+                        scheduleRetry(deviceInfo)
+                        return
+                    }
+                }
                 disconnect()
                 return
             }
             if (newState == BluetoothGatt.STATE_CONNECTED) {
                 HLog.d(TAG, "Connected, discovering services...")
+                connectionRetryCount = 0 // Reset retry counter on successful connection
                 gatt.discoverServices()
             } else if (newState == BluetoothGatt.STATE_DISCONNECTED) {
                 disconnect()
@@ -179,6 +235,16 @@ object BluetoothHandler {
 
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
+                HLog.d(TAG, "Service discovery failed: status=$status")
+                // Retry service discovery instead of immediately disconnecting
+                if (connectionRetryCount < MAX_CONNECTION_RETRIES) {
+                    val deviceName = bluetoothDevice?.name ?: "unknown"
+                    val deviceInfo = supportedDevices.find { it.deviceName == deviceName }
+                    if (deviceInfo != null) {
+                        scheduleRetry(deviceInfo)
+                        return
+                    }
+                }
                 disconnect()
                 return
             }

--- a/app/src/main/java/com/example/howl/OutputCoyote3.kt
+++ b/app/src/main/java/com/example/howl/OutputCoyote3.kt
@@ -37,8 +37,11 @@ class Coyote3Output : BaseOutput() {
     var setupStage: CoyoteSetupStage = CoyoteSetupStage.Initial
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var batteryPollJob: Job? = null
+    private var setupTimeoutJob: Job? = null
     private var previousChannelAPower = -1
     private var previousChannelBPower = -1
+    private var reconnectCount = 0
+    private val maxReconnects = 4
 
     companion object {
         const val TAG = "Coyote3Output"
@@ -62,17 +65,39 @@ class Coyote3Output : BaseOutput() {
         batteryPollJob?.cancel()
     }
 
+    private fun autoReconnect() {
+        reconnectCount++
+        if (reconnectCount <= maxReconnects) {
+            HLog.d(TAG, "Auto-reconnecting (attempt $reconnectCount/$maxReconnects)...")
+            BluetoothHandler.disconnect()
+            BluetoothHandler.attemptConnection()
+        } else {
+            HLog.d(TAG, "Max auto-reconnects reached, giving up")
+            BluetoothHandler.disconnect()
+        }
+    }
+
     override fun handleBluetoothEvent(event: BluetoothEvent) {
+        Log.v(TAG, "Event: ${event.type} stage=$setupStage success=${event.success}")
         when (event.type) {
             BluetoothEventType.Connected -> {
                 setupStage = CoyoteSetupStage.RegisterForStatusUpdates
-                BluetoothHandler.subscribeToCharacteristic(mainServiceUUID, notifyCharacteristicUUID)
+                startSetupTimeout()
+                val subscribed = BluetoothHandler.subscribeToCharacteristic(mainServiceUUID, notifyCharacteristicUUID)
+                if (!subscribed) {
+                    HLog.d(TAG, "Failed to subscribe to notify characteristic, reconnecting...")
+                    autoReconnect()
+                }
             }
             BluetoothEventType.Disconnected -> {
                 ready = false
                 setupStage = CoyoteSetupStage.Initial
                 batteryPollJob?.cancel()
                 batteryPollJob = null
+                setupTimeoutJob?.cancel()
+                setupTimeoutJob = null
+                // Don't reset reconnectCount here — auto-reconnect calls disconnect+attemptConnection
+                // in sequence; resetting would break the retry limit. It's reset on successful setup.
             }
             BluetoothEventType.CharacteristicRead-> {
                 // Battery level message
@@ -106,12 +131,15 @@ class Coyote3Output : BaseOutput() {
             BluetoothEventType.CharacteristicWrite -> {
                 if (event.serviceUuid == mainServiceUUID && event.characteristicUuid == writeCharacteristicUUID) {
                     if (setupStage == CoyoteSetupStage.SyncParameters) {
-                        // assume the response is for our sync
                         if (event.success != true) {
-                            BluetoothHandler.disconnect()
+                            HLog.d(TAG, "Parameter sync write failed, reconnecting...")
+                            autoReconnect()
                             return
                         }
+                        reconnectCount = 0  // Reset reconnect counter on successful setup
                         setupStage = CoyoteSetupStage.Ready
+                        setupTimeoutJob?.cancel()
+                        setupTimeoutJob = null
                         startBatteryPolling()
                         ready = true
                     }
@@ -121,11 +149,18 @@ class Coyote3Output : BaseOutput() {
                 // Response to our subscription request
                 if (event.serviceUuid == mainServiceUUID && event.characteristicUuid == notifyCharacteristicUUID) {
                     if (event.success != true) {
-                        BluetoothHandler.disconnect()
+                        HLog.d(TAG, "Descriptor write failed, reconnecting...")
+                        // Tear down and re-establish connection - this is more reliable than
+                        // retrying the write within the same connection
+                        autoReconnect()
                         return
                     }
                     setupStage = CoyoteSetupStage.SyncParameters
-                    syncParameters()
+                    val synced = syncParameters()
+                    if (!synced) {
+                        HLog.d(TAG, "Failed to sync parameters, reconnecting...")
+                        autoReconnect()
+                    }
                 }
             }
             BluetoothEventType.Error -> {
@@ -167,7 +202,7 @@ class Coyote3Output : BaseOutput() {
         BluetoothHandler.sendToDevice(mainServiceUUID, writeCharacteristicUUID, command)
     }
 
-    fun sendParameters(parameters: Coyote3Parameters) {
+    fun sendParameters(parameters: Coyote3Parameters): Boolean {
         val command = byteArrayOf(
             0xBF.toByte(),
             parameters.channelALimit.toByte(),
@@ -178,10 +213,10 @@ class Coyote3Output : BaseOutput() {
             parameters.channelBIntensityBalance.toByte()
         )
         Log.v(TAG, "Sending BF command, data: ${command.toHexString()}")
-        BluetoothHandler.sendToDevice(mainServiceUUID, writeCharacteristicUUID, command)
+        return BluetoothHandler.sendToDevice(mainServiceUUID, writeCharacteristicUUID, command)
     }
 
-    fun syncParameters() {
+    fun syncParameters(): Boolean {
         // Send the Coyote 3 parameters according to the current app preferences
         val params = Coyote3Parameters(
             channelALimit = Prefs.powerLimitA.value,
@@ -191,7 +226,18 @@ class Coyote3Output : BaseOutput() {
             channelAIntensityBalance = Prefs.outputC3IntensityBalanceA.value,
             channelBIntensityBalance = Prefs.outputC3IntensityBalanceB.value
         )
-        sendParameters(params)
+        return sendParameters(params)
+    }
+
+    private fun startSetupTimeout() {
+        setupTimeoutJob?.cancel()
+        setupTimeoutJob = scope.launch {
+            delay(8000) // 8 seconds to complete setup
+            if (setupStage != CoyoteSetupStage.Ready) {
+                HLog.d(TAG, "Setup timed out at stage $setupStage, disconnecting")
+                BluetoothHandler.disconnect()
+            }
+        }
     }
 
     private fun pollBatteryLevel() {


### PR DESCRIPTION
Add multiple retries and waits during initial bluetooth BLE connection.

There seems to be an issue in the latest firmware, where GATT calls randomly fail and the BLE advertisment messages are sometimes garbled..

For me these changes fix the issue / i couldn´t reproduce the connection failures anymore..

Should fix #22 