### PR TITLE
Fix missing Timer registration in Opposite Activity

### DIFF
--- a/app/src/main/java/com/example/howl/Activity.kt
+++ b/app/src/main/java/com/example/howl/Activity.kt
@@ -1117,10 +1117,11 @@ class OppositesActivity : Activity() {
         newRandomAmplitudeTarget(ampA)
         newRandomFrequencyTarget(freqA)
         speedChange()
-        speedChangeTimer.start()
         manager.register(ampA)
         manager.register(freqA)
+        manager.register(speedChangeTimer)
         manager.register(overallSpeed)
+        speedChangeTimer.start()
     }
 
     private fun speedChange() {


### PR DESCRIPTION
I think this Timer needs to be registered for update to be called. Probably?